### PR TITLE
Fix to stop (Workstation) from overwriting (Coral)

### DIFF
--- a/build/korora-release.spec
+++ b/build/korora-release.spec
@@ -144,7 +144,6 @@ cp -p $RPM_BUILD_ROOT/usr/lib/os.release.d/os-release-fedora \
       $RPM_BUILD_ROOT/usr/lib/os.release.d/os-release-workstation
 echo "VARIANT=\"Workstation Edition\"" >> $RPM_BUILD_ROOT/usr/lib/os.release.d/os-release-workstation
 echo "VARIANT_ID=workstation" >> $RPM_BUILD_ROOT/usr/lib/os.release.d/os-release-workstation
-sed -i -e "s|(%{release_name})|(Workstation Edition)|g" $RPM_BUILD_ROOT/usr/lib/os.release.d/os-release-workstation
 
 # Create the symlink for /etc/os-release
 # This will be standard until %post when the


### PR DESCRIPTION
Upstream change in F23 added the line in question to replace the defined release_name with "Workstation Edition" when using that edition, resulting in the /etc/os-release file having `VERSION="23 (Workstation Edition)"` and `PRETTY_NAME= Korora 23 (Workstation Edition)` also resulting in GRUB naming the boot options with those variables. 

Tested that this occurs during upgrade from Korora 22 to 23.

Removal of line will stop that behavior and leave (Coral) in /etc/os-release
